### PR TITLE
feat: mandatory TDD for software + Protect Main rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,8 @@ Utilities: `/bmad-init`, `/bmad-shard`
 - Output artifacts go to `.claude/bmad-output/` in the target project (not this repo)
 - Quality gates: P0=REJECT, P1=CONDITIONAL PASS, P2=PASS with notes, P3=PASS
 - After `git mv` of skill directories, Read each file at its new path before editing — tool tracks read state by path
+- **TDD mandatory** (software domain): `bmad-impl` enforces red-green-refactor; `bmad-qa` issues P0 REJECT if `tdd-checklist.md` missing. Configurable via `roles.qa.tdd_enforcement` in bmad-config.yaml (`strict`/`relaxed`/`off`)
+- **Protect Main**: never work directly on `main`/`master` — soul.md principle + Git Branch Guard in `bmad-impl` and `bmad-greenfield`
 
 ## Testing / Validation
 - `claude --plugin-dir ./claude-plugin-bmad` — local dev testing
@@ -49,10 +51,15 @@ Utilities: `/bmad-init`, `/bmad-shard`
 - Check no old role names: `grep -r "bmad-analyst\|bmad-pm\|/bmad-architect\|/bmad-dev\|/bmad-sm" skills/ commands/`
 - After renaming skills, check no stale references: `grep -r "old-name" skills/ commands/ resources/ README.md docs/`
 - Cross-reference scan should cover ALL text files including templates and documentation, not just skills/
+- Check TDD in impl: `grep -r "red-green-refactor" skills/bmad-impl/` (should match)
+- Check TDD enforcement in QA: `grep -r "TDD compliance" skills/bmad-qa/` (should match)
+- Check Branch Guard: `grep -r "Branch Guard" skills/bmad-impl/ skills/bmad-greenfield/` (should match both)
+- Check tdd-checklist template exists: `[ -f resources/templates/software/tdd-checklist.md ] && echo OK`
 
 ## Related Repositories
 - Company version (holacracy, quality gates): github.com/alessioroberto82/claude-plugin-bmad
 - PR #1 (`feat/holacracy-evolution`): holacracy migration with soul.md, P0-P3 gates, role renames (merged)
+- PR #2 (`feat/mandatory-tdd-and-branch-protection`): mandatory TDD for software, Protect Main rule, tdd-checklist template
 
 ## Installation (for users)
 - Local: `claude plugin install ./claude-plugin-bmad`

--- a/resources/soul.md
+++ b/resources/soul.md
@@ -24,6 +24,12 @@ These principles guide every role in the BMAD circle.
 - Trust the process, trust the circle
 - Escalate tensions, not approvals
 
+### Protect Main
+- In git projects, NEVER commit directly to `main` (or `master`) — always work on a dedicated branch
+- Create a feature branch before any implementation begins
+- The main branch is sacred: only merge via PR after quality gates pass
+- If you detect you are on `main`, STOP and create a branch before proceeding
+
 ## Domain Adaptations
 
 ### Software

--- a/resources/templates/config-example.yaml
+++ b/resources/templates/config-example.yaml
@@ -25,6 +25,14 @@ workflow:
 
 # Role overrides (customize individual role behavior)
 roles:
+  # QA Guardian overrides
+  qa:
+    # TDD enforcement level for software domain
+    # "strict" (default): P0 REJECT if tdd-checklist.md missing
+    # "relaxed": P1 CONDITIONAL PASS if tdd-checklist.md missing
+    # "off": skip TDD compliance check entirely
+    tdd_enforcement: strict
+
   # Example: customize the architecture owner
   # arch:
   #   extra_instructions: |

--- a/resources/templates/software/tdd-checklist.md
+++ b/resources/templates/software/tdd-checklist.md
@@ -1,0 +1,36 @@
+# TDD Checklist
+
+**Project**: {Project Name}
+**Story/Feature**: {Story ID or Feature Name}
+**Date**: {Date}
+**Owner**: Implementer
+
+---
+
+## TDD Cycles
+
+| # | Behavior | RED: Test Written | RED: Fails? | GREEN: Code Written | GREEN: Passes? | REFACTOR: Changes | Notes |
+|---|----------|-------------------|-------------|---------------------|----------------|-------------------|-------|
+| 1 | {What behavior is being tested} | {Test file:function} | Yes/No | {Implementation summary} | Yes/No | {Refactor summary or "None"} | |
+| 2 | | | | | | | |
+| 3 | | | | | | | |
+
+---
+
+## Coverage Summary
+
+- Tests written: {count}
+- Tests passing: {count}
+- Requirements covered: {list FR-x.x IDs}
+- Requirements NOT covered: {list or "None"}
+
+---
+
+## Compliance Verdict
+
+- [ ] Every behavior was tested BEFORE implementation (red-green-refactor)
+- [ ] All acceptance criteria from PRD have corresponding test(s)
+- [ ] No implementation code exists without a preceding test
+- [ ] Refactoring preserved all green tests
+
+**TDD Compliant**: Yes / No

--- a/skills/bmad-arch/SKILL.md
+++ b/skills/bmad-arch/SKILL.md
@@ -44,6 +44,7 @@ If no config file exists, use default behavior.
 - Component Architecture (modules, services, database)
 - ADRs (Architecture Decision Records) for key choices
 - Technology Stack with justifications
+- Testability (DI strategy, mocking boundaries, test isolation)
 - Performance & Scalability considerations
 - Security considerations
 
@@ -88,6 +89,7 @@ If no config file exists, use default behavior.
 **Decision**: What we decided
 **Alternatives Considered**: Other options evaluated
 **Consequences**: Pros/cons of the decision
+**Testability Impact**: How this decision affects test isolation, DI, and mocking (software domain)
 ```
 
 ## BMAD Principles

--- a/skills/bmad-greenfield/SKILL.md
+++ b/skills/bmad-greenfield/SKILL.md
@@ -72,6 +72,22 @@ if [ -f ".claude/bmad-output/session-state.json" ]; then
 fi
 ```
 
+**Git Branch Guard**:
+
+If the project is a git repository, check the current branch BEFORE proceeding:
+```bash
+BRANCH=$(git branch --show-current 2>/dev/null)
+if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
+  echo "You are on '$BRANCH'. BMAD requires a dedicated branch."
+  echo ""
+  echo "Please create a feature branch before starting the workflow:"
+  echo "  git checkout -b feat/<project-name>"
+  echo ""
+  echo "This is a hard block — the BMAD circle never works directly on main."
+  # STOP HERE — do not proceed until user switches branch
+fi
+```
+
 **Initialize structure** (if it doesn't exist):
 ```bash
 mkdir -p .claude/bmad-output
@@ -532,7 +548,7 @@ Duration: 30-60 minutes (interactive ceremony)
 The Implementer builds the solution based on design.
 
 What to expect:
-- Code implementation (software)
+- Code implementation (software) — TDD required: red-green-refactor workflow will be enforced
 - Documentation creation (business)
 - Tool/tracker setup (personal)
 - Self-review before handoff
@@ -542,7 +558,7 @@ Duration: Variable (hours to days)
 
 **Agent**: `/bmad-impl`
 
-**Expected Artifact**: Implementation (code, documents, tools)
+**Expected Artifact**: Implementation (code, documents, tools). For software domain: also `tdd-checklist.md` in `.claude/bmad-output/`.
 
 **Note**: This phase may take multiple sessions. User can pause and resume.
 
@@ -555,6 +571,7 @@ Duration: Variable (hours to days)
 The Quality Guardian validates implementation against requirements.
 
 What to expect:
+- TDD compliance check (software domain): verifies tdd-checklist.md exists
 - Test execution and results
 - P0-P3 severity rating for issues found
 - Edge case analysis
@@ -566,6 +583,25 @@ Duration: 30-60 minutes
 **Agent**: `/bmad-qa`
 
 **Expected Artifact**: `test-report.md` | `validation-report.md` | `readiness-check.md`
+
+**TDD Pre-Check (software domain only)**:
+```bash
+# Before invoking QA, check TDD evidence exists
+if [ "$DOMAIN" = "software" ]; then
+  if [ ! -f ".claude/bmad-output/tdd-checklist.md" ]; then
+    echo "WARNING: tdd-checklist.md not found"
+    echo ""
+    echo "The Implementer should have produced a TDD checklist."
+    echo "Without it, QA will issue a P0 REJECT."
+    echo ""
+    echo "Options:"
+    echo "[f] Fix - go back to /bmad-impl to complete TDD"
+    echo "[c] Continue anyway (QA will likely REJECT)"
+    echo ""
+    echo "Your choice: _"
+  fi
+fi
+```
 
 **Quality Gate Check**:
 ```bash

--- a/skills/bmad-impl/SKILL.md
+++ b/skills/bmad-impl/SKILL.md
@@ -38,18 +38,27 @@ If no config file exists, use default behavior.
 ## Domain-Specific Behavior
 
 ### Software Development
+
+**TDD is mandatory for software projects.** Every behavior must be implemented using the red-green-refactor cycle. The Implementer produces a `tdd-checklist.md` artifact that the QA Guardian will verify.
+
 **Activities**:
-- Implement features according to PRD and architecture
-- Write code following best practices and existing patterns
-- Create tests (unit, integration)
+- Write failing tests BEFORE implementation code (red-green-refactor)
+- Implement minimal code to pass each test
+- Refactor while keeping tests green
+- Log each TDD cycle in `tdd-checklist.md`
 - Document APIs and complex functions
 - Self-review before handoff
 
 **Workflow**:
 1. Read story/task to implement (if sharding is present, read specific shard)
-2. Implement following architecture and existing patterns
-3. Add tests for coverage
-4. Update documentation if necessary
+2. Initialize `tdd-checklist.md` using template `${CLAUDE_PLUGIN_ROOT}/resources/templates/software/tdd-checklist.md`, write to `.claude/bmad-output/tdd-checklist.md`
+3. **For each behavior/acceptance criterion**:
+   - **RED**: Write a failing test that defines the expected behavior. Run it — verify it fails.
+   - **GREEN**: Write the minimal code to make the test pass. Run it — verify it passes.
+   - **REFACTOR**: Clean up code and tests while keeping all tests green.
+   - **LOG**: Record the cycle in `tdd-checklist.md` (test name, red/green results, refactor notes).
+4. After all behaviors are covered, update the Coverage Summary and Compliance Verdict in `tdd-checklist.md`
+5. Update documentation if necessary
 
 ### Business Strategy
 **Activities**:
@@ -86,18 +95,31 @@ If directory `.claude/bmad-output/shards/stories/` exists:
 
 **Benefit**: 90% token reduction, absolute focus on current task
 
+## Git Branch Guard
+
+Before ANY implementation work, if the project is a git repository:
+
+1. Check the current branch: `git branch --show-current`
+2. If on `main` or `master`: **STOP. Do not proceed.**
+   - Inform the user: "You are on `main`. The BMAD circle requires a dedicated branch for all work. Create a feature branch before continuing."
+   - Suggest: `git checkout -b feat/<descriptive-name>`
+3. If on a feature branch: proceed normally.
+
+This is a **hard block** — no exceptions. The main branch is protected by circle principles (`soul.md`).
+
 ## Process
 
-1. **Validate context**: Verify that design/plan exists
-2. **Identify task**: What to implement (from args or from architecture)
-3. **Implement**: Write code/documents/tools
-4. **Self-review**: Verify quality before handoff
-5. **Handoff**:
+1. **Branch guard**: Verify NOT on main/master (see above)
+2. **Validate context**: Verify that design/plan exists
+3. **Identify task**: What to implement (from args or from architecture)
+4. **Implement**: Write code/documents/tools
+5. **Self-review**: Verify quality before handoff
+6. **Handoff**:
    > **Implementer — Complete.**
    > Next suggested role: `/bmad-qa` for quality validation.
 
 ## BMAD Principles
 - Follow the design: don't invent solutions different from those architected
-- Test as you go: implement + test together
+- Test first: red-green-refactor is the law for software projects
 - Context isolation: if using sharding, focus only on current task
 - No gold-plating: solve the problem at hand, nothing more

--- a/skills/bmad-prioritize/SKILL.md
+++ b/skills/bmad-prioritize/SKILL.md
@@ -48,6 +48,8 @@ If no config file exists, use default behavior.
 - Prioritization (Must Have / Should Have / Could Have / Won't Have)
 - Success Metrics
 
+**TDD Requirement**: Write acceptance criteria as testable assertions. Use GIVEN/WHEN/THEN format or explicit input→expected output. Every functional requirement must map to at least one verifiable test scenario — the Implementer will derive TDD test cases directly from these criteria.
+
 **Template**: `${CLAUDE_PLUGIN_ROOT}/resources/templates/software/PRD.md`
 
 ### Business Strategy
@@ -90,6 +92,7 @@ If no config file exists, use default behavior.
 
 ## BMAD Principles
 - Specific and measurable: every requirement must have acceptance criteria
+- Testable requirements: every acceptance criterion must be verifiable by a test
 - Progressive disclosure: don't think about implementation, only about requirements
 - Human validation: ask for confirmation on priorities and scope if ambiguous
 - Impact over activity: ruthlessly prioritize what matters most


### PR DESCRIPTION
## Summary

- **Mandatory TDD** for all software domain projects: strict red-green-refactor enforced by `bmad-impl`, verified by `bmad-qa` with P0 REJECT if `tdd-checklist.md` missing
- **Protect Main** as core circle principle in `soul.md`: Git Branch Guard blocks work on `main`/`master` in both `bmad-impl` and `bmad-greenfield`
- **Testability** integrated upstream: `bmad-prioritize` requires GIVEN/WHEN/THEN criteria, `bmad-arch` adds Testability section + ADR field
- **Configurable**: `tdd_enforcement: strict|relaxed|off` in `bmad-config.yaml`

## Files Changed (8)

| File | Change |
|------|--------|
| `resources/soul.md` | New "Protect Main" core principle |
| `resources/templates/software/tdd-checklist.md` | **NEW** — TDD cycle evidence template |
| `resources/templates/config-example.yaml` | `tdd_enforcement` config key |
| `skills/bmad-prioritize/SKILL.md` | Testable criteria guidance (GIVEN/WHEN/THEN) |
| `skills/bmad-arch/SKILL.md` | Testability in output + ADR format |
| `skills/bmad-impl/SKILL.md` | Red-green-refactor workflow + Git Branch Guard |
| `skills/bmad-qa/SKILL.md` | TDD compliance check (P0 REJECT) + config override |
| `skills/bmad-greenfield/SKILL.md` | TDD gate (Phase 8+9) + Git Branch Guard (init) |

## Test plan

- [ ] Verify all 12 skills have SKILL.md with YAML frontmatter
- [ ] Verify no hardcoded `/Users/` paths: `grep -r '/Users/' skills/ resources/`
- [ ] Verify no old role names: `grep -r 'bmad-analyst\|bmad-pm\|/bmad-architect' skills/`
- [ ] Verify all skills reference soul.md: `grep -l 'soul.md' skills/*/SKILL.md | wc -l` = 12
- [ ] Verify TDD keywords present: `grep -r 'red-green-refactor' skills/bmad-impl/`
- [ ] Verify TDD enforcement: `grep -r 'TDD compliance' skills/bmad-qa/`
- [ ] Verify Protect Main: `grep -r 'Branch Guard' skills/bmad-impl/ skills/bmad-greenfield/`
- [ ] Verify tdd-checklist.md template < 2000 tokens
- [ ] Test `/bmad-impl` on a software project enforces TDD workflow
- [ ] Test `/bmad-qa` on software without tdd-checklist.md triggers P0 REJECT

🤖 Generated with [Claude Code](https://claude.com/claude-code)