### PR TITLE
feat: dynamic governance — tension sensing and role proposals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,9 @@ No build step, no npm, no traditional tests. All content is Markdown.
 - `skills/bmad-<name>/SKILL.md` — auto-discovered skills (YAML frontmatter required)
 - `commands/<name>.md` — simple slash commands (no frontmatter)
 - `resources/soul.md` — shared circle principles (loaded by every role)
+- `resources/governance-protocol.md` — dynamic governance protocol (tension detection, role proposals, promotion)
 - `resources/templates/<domain>/<name>.md` — output scaffolds (software/business/personal)
+- `resources/templates/software/role-template.md` — template for generating new SKILL.md via promotion
 - `resources/templates/config-example.yaml` — per-project config template
 - `.claude-plugin/plugin.json` — plugin manifest
 - `docs/CUSTOMIZATION.md` — contributor guide with templates
@@ -48,6 +50,7 @@ Utilities: `/bmad-init`, `/bmad-shard`
 - GitHub Actions: always pass `${{ steps.* }}` via `env:` blocks, never inline in `run:` scripts (injection prevention)
 - Zsh shell: quote `gh api` URLs containing `?` (e.g., `gh api 'repos/.../contents/dir?ref=tag'`)
 - Git rebase continue: use `GIT_EDITOR=true git rebase --continue` (no `--no-edit` flag exists for rebase)
+- **Dynamic Governance**: all 8 agent roles have a `## Tension Sensing` block that references `governance-protocol.md`. Orchestrators have a `## Temporary Roles` section. New roles can be proposed, approved, used temporarily, and promoted to permanent SKILL.md files.
 
 ## Testing / Validation
 - `claude --plugin-dir ./claude-plugin-bmad` — local dev testing
@@ -62,6 +65,11 @@ Utilities: `/bmad-init`, `/bmad-shard`
 - Check TDD enforcement in QA: `grep -r "TDD compliance" skills/bmad-qa/` (should match)
 - Check Branch Guard: `grep -r "Branch Guard" skills/bmad-impl/ skills/bmad-greenfield/` (should match both)
 - Check tdd-checklist template exists: `[ -f resources/templates/software/tdd-checklist.md ] && echo OK`
+- Check governance protocol exists: `[ -f resources/governance-protocol.md ] && echo OK`
+- Check role template exists: `[ -f resources/templates/software/role-template.md ] && echo OK`
+- Check Tension Sensing in agent roles: `grep -l "Tension Sensing" skills/bmad-{scope,prioritize,arch,impl,qa,ux,security,facilitate}/SKILL.md | wc -l` (should be 8)
+- Check Temporary Roles in orchestrators: `grep -l "Temporary Roles" skills/bmad-{greenfield,sprint}/SKILL.md | wc -l` (should be 2)
+- Check governance-protocol.md sections: `grep -c "Tension Format\|Proposal Flow\|Temporary Role Format\|Promotion Rules" resources/governance-protocol.md` (should be 4)
 
 ## Related Repositories
 - Company version (holacracy, quality gates): github.com/alessioroberto82/claude-plugin-bmad

--- a/resources/governance-protocol.md
+++ b/resources/governance-protocol.md
@@ -1,0 +1,85 @@
+# Governance Protocol
+
+This protocol defines how the BMAD circle evolves dynamically. When an agent detects a gap in the circle, it follows this protocol to propose new roles — always with human approval.
+
+## Tension Format
+
+When you detect a task outside your scope that no existing BMAD role covers, formulate a tension:
+
+```
+TENSION DETECTED
+================
+Gap: [What task or responsibility is missing from the circle]
+Suggested Role: bmad-<name>
+Purpose: [What this role would do in the circle]
+Accountabilities:
+  - [Responsibility 1]
+  - [Responsibility 2]
+  - [Responsibility 3]
+Domain: software | business | personal | general
+```
+
+## Existing Roles Reference
+
+Before proposing a new role, verify the gap is real. These roles already exist:
+- **bmad-scope**: Vision, scope, briefs
+- **bmad-prioritize**: Requirements, PRDs, priorities
+- **bmad-ux**: User research, wireframes, journeys
+- **bmad-arch**: Architecture, ADRs, system design
+- **bmad-security**: Threat modeling, compliance, audits
+- **bmad-facilitate**: Sprint/quarter/week planning
+- **bmad-impl**: Code, content, action implementation
+- **bmad-qa**: Testing strategy, quality validation
+- **bmad-greenfield**: Full workflow orchestration
+- **bmad-sprint**: Sprint ceremony orchestration
+
+If an existing role covers the task, suggest invoking that role instead of creating a new one.
+
+## Proposal Flow
+
+1. **Present the tension** to the user using the format above
+2. **Offer options**: Approve / Reject / Modify
+   - **Approve**: Create the temporary role immediately
+   - **Reject**: Continue your current work, no role created
+   - **Modify**: User adjusts name, purpose, or accountabilities before creation
+3. **If approved**: Create the temporary role in the current session context
+
+## Temporary Role Format
+
+When creating a temporary role after approval, establish it in the conversation with:
+
+```
+TEMPORARY ROLE CREATED
+======================
+Name: bmad-<name>
+Purpose: [Purpose as approved by user]
+Accountabilities:
+  - [As approved]
+Principles: Follow soul.md (Growth Over Ego, Iteration Over Perfection, Impact Over Activity, Distributed Authority)
+
+This role is active for the current session only.
+```
+
+The temporary role:
+- Can be invoked by orchestrators as if it were a permanent role
+- Follows the same BMAD principles from soul.md
+- Has no SKILL.md on filesystem (exists only in conversation context)
+- Ceases to exist when the session ends
+
+## Promotion Rules
+
+Track how many times a temporary role is used in the session. When the count reaches **2 or more uses**:
+
+1. **Suggest promotion**: "The temporary role bmad-<name> has been used N times this session. Would you like to make it permanent?"
+2. **If confirmed**: Generate a SKILL.md using the role template at `${CLAUDE_PLUGIN_ROOT}/resources/templates/software/role-template.md`
+   - Create directory: `skills/bmad-<name>/`
+   - Write `skills/bmad-<name>/SKILL.md` with all standard blocks (frontmatter, soul.md, domain detection, config, process, tension sensing)
+   - Use `${CLAUDE_PLUGIN_ROOT}/` for all paths (never hardcode absolute paths)
+3. **If rejected**: Do not suggest again in this session
+
+## Governance Principles
+
+- **Human-in-the-loop**: Never create a role without explicit user approval
+- **Minimal disruption**: Tension sensing should not interrupt normal work flow for minor gaps
+- **Single responsibility**: Each proposed role should have a clear, distinct purpose
+- **Circle coherence**: New roles should complement, not overlap with, existing roles

--- a/resources/templates/software/role-template.md
+++ b/resources/templates/software/role-template.md
@@ -1,0 +1,72 @@
+# Role Template for SKILL.md Generation
+
+Use this template when promoting a temporary role to a permanent SKILL.md. Replace all `{{PLACEHOLDER}}` values with the actual role data.
+
+---
+
+```markdown
+---
+name: bmad-{{NAME}}
+description: BMAD {{DISPLAY_NAME}} - {{DESCRIPTION}}
+context: fork
+agent: general-purpose
+---
+
+# {{DISPLAY_NAME}}
+
+You energize the **{{DISPLAY_NAME}}** role in the BMAD circle. {{PURPOSE}}
+
+## Shared Principles
+
+Read the BMAD circle principles from `${CLAUDE_PLUGIN_ROOT}/resources/soul.md` and apply them throughout this session.
+
+## Domain Detection
+
+Detect the project domain by analyzing files in the current directory:
+- **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
+- **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
+- **general**: default if no indicator found
+
+## Configuration
+
+If `.claude/bmad-output/bmad-config.yaml` exists, read it and apply overrides:
+- Check for role-specific overrides in `roles.{{NAME}}`
+- Check for domain override in `domain`
+
+If no config file exists, use default behavior.
+
+## Process
+
+{{ACCOUNTABILITIES_AS_PROCESS_STEPS}}
+
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope and no existing BMAD role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.
+
+## BMAD Principles
+- Follow circle principles from soul.md
+- Human-in-the-loop: ask questions, never assume
+- Impact over activity: solve the problem at hand, nothing more
+```
+
+---
+
+## Placeholder Reference
+
+| Placeholder | Source | Example |
+|---|---|---|
+| `{{NAME}}` | Role slug (lowercase, hyphenated) | `data-analyst` |
+| `{{DISPLAY_NAME}}` | Human-readable role name | `Data Analyst` |
+| `{{DESCRIPTION}}` | One-line role description | `analyzes data, creates reports, identifies trends` |
+| `{{PURPOSE}}` | Role purpose statement | `You analyze data to surface insights that drive decisions.` |
+| `{{ACCOUNTABILITIES_AS_PROCESS_STEPS}}` | Numbered list from accountabilities | `1. **Collect data**: ...\n2. **Analyze**: ...` |

--- a/skills/bmad-arch/SKILL.md
+++ b/skills/bmad-arch/SKILL.md
@@ -92,6 +92,19 @@ If no config file exists, use default behavior.
 **Testability Impact**: How this decision affects test isolation, DI, and mocking (software domain)
 ```
 
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope and no existing BMAD role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.
+
 ## BMAD Principles
 - Document trade-offs: every choice has pros/cons, document them
 - Think scalability: consider growth and future changes

--- a/skills/bmad-facilitate/SKILL.md
+++ b/skills/bmad-facilitate/SKILL.md
@@ -124,6 +124,19 @@ If no config file exists, use default behavior.
    > Output saved to: `.claude/bmad-output/<plan-file>.md`
    > Next suggested role: `/bmad-impl` for implementation.
 
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope and no existing BMAD role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.
+
 ## BMAD Principles
 
 - **Iterative planning**: Focus on current period, not the entire project

--- a/skills/bmad-greenfield/SKILL.md
+++ b/skills/bmad-greenfield/SKILL.md
@@ -1094,6 +1094,12 @@ Your choice: _
 
 ---
 
+## Temporary Roles
+
+If temporary roles have been created during this session via the Governance Protocol (`${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`), include them in your workflow planning when relevant. Temporary roles can be invoked like any other BMAD role — they exist in the conversation context and follow the same circle principles.
+
+When presenting the workflow plan, list any active temporary roles alongside the standard roles.
+
 ## BMAD Principles
 
 ### 1. Human-in-the-Loop

--- a/skills/bmad-impl/SKILL.md
+++ b/skills/bmad-impl/SKILL.md
@@ -118,6 +118,19 @@ This is a **hard block** — no exceptions. The main branch is protected by circ
    > **Implementer — Complete.**
    > Next suggested role: `/bmad-qa` for quality validation.
 
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope and no existing BMAD role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.
+
 ## BMAD Principles
 - Follow the design: don't invent solutions different from those architected
 - Test first: red-green-refactor is the law for software projects

--- a/skills/bmad-prioritize/SKILL.md
+++ b/skills/bmad-prioritize/SKILL.md
@@ -90,6 +90,19 @@ If no config file exists, use default behavior.
    > Output saved to: `.claude/bmad-output/<requirements-file>.md`
    > Next suggested role: `/bmad-arch` for solution architecture, or `/bmad-ux` for experience design.
 
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope and no existing BMAD role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.
+
 ## BMAD Principles
 - Specific and measurable: every requirement must have acceptance criteria
 - Testable requirements: every acceptance criterion must be verifiable by a test

--- a/skills/bmad-qa/SKILL.md
+++ b/skills/bmad-qa/SKILL.md
@@ -199,6 +199,19 @@ Based on findings:
 > **Quality Guardian — PASS.**
 > Quality gate passed. Ready for deployment/release.
 
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope and no existing BMAD role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.
+
 ## BMAD Principles
 - **Quality gates matter**: P0 = hard block, no exceptions
 - **Coverage that matters**: test critical paths, not ceremony

--- a/skills/bmad-scope/SKILL.md
+++ b/skills/bmad-scope/SKILL.md
@@ -67,6 +67,19 @@ If no config file exists, use default behavior.
    > Output saved to: `.claude/bmad-output/<brief-file>.md`
    > Next suggested role: `/bmad-prioritize` to define priorities and detailed requirements.
 
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope and no existing BMAD role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.
+
 ## BMAD Principles
 - Human-in-the-loop: ask questions, never assume
 - Progressive disclosure: focus only on scope clarification

--- a/skills/bmad-security/SKILL.md
+++ b/skills/bmad-security/SKILL.md
@@ -191,6 +191,19 @@ Based on findings:
 - Future-proofing
 - **Action**: Consider for next major version
 
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope and no existing BMAD role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.
+
 ## BMAD Principles
 
 - **Defense in Depth**: Multiple layers of security, not single point of failure

--- a/skills/bmad-sprint/SKILL.md
+++ b/skills/bmad-sprint/SKILL.md
@@ -480,6 +480,10 @@ Try again: _
 }
 ```
 
+## Temporary Roles
+
+If temporary roles have been created during this session via the Governance Protocol (`${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`), include them in your ceremony planning when relevant. Temporary roles can be invoked like any other BMAD role — they exist in the conversation context and follow the same circle principles.
+
 ## BMAD Principles
 
 - **Human-in-the-Loop**: Ask for input at every step, don't assume

--- a/skills/bmad-ux/SKILL.md
+++ b/skills/bmad-ux/SKILL.md
@@ -130,6 +130,19 @@ If no config file exists, use default behavior.
    > Output saved to: `.claude/bmad-output/<design-file>.md`
    > Next suggested role: `/bmad-arch` for architecture, or `/bmad-impl` for implementation.
 
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope and no existing BMAD role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.
+
 ## BMAD Principles
 
 - **User-centered**: Always start from real needs, not assumptions


### PR DESCRIPTION
## Summary
- Add **dynamic governance** to the BMAD circle: agents detect gaps (tensions) and propose new roles with mandatory human approval
- New shared `governance-protocol.md` resource defining tension format, proposal flow, temporary role lifecycle, and promotion rules
- New `role-template.md` for generating SKILL.md when promoting temporary roles to permanent
- All 8 agent roles gain a `## Tension Sensing` block referencing the governance protocol
- Both orchestrators (greenfield, sprint) gain a `## Temporary Roles` section for visibility of in-session roles
- CLAUDE.md updated with governance documentation and 5 new validation checks

## Test plan
- [ ] Verify `resources/governance-protocol.md` exists and has 4 required sections (Tension Format, Proposal Flow, Temporary Role Format, Promotion Rules)
- [ ] Verify `resources/templates/software/role-template.md` exists with placeholders
- [ ] Verify all 8 agent roles have identical `## Tension Sensing` block: `grep -l "Tension Sensing" skills/bmad-{scope,prioritize,arch,impl,qa,ux,security,facilitate}/SKILL.md | wc -l` → 8
- [ ] Verify orchestrators have `## Temporary Roles`: `grep -l "Temporary Roles" skills/bmad-{greenfield,sprint}/SKILL.md | wc -l` → 2
- [ ] Verify no hardcoded paths: `grep -r '/Users/' skills/ commands/ resources/` → empty
- [ ] Verify all SKILL.md start with `---` frontmatter
- [ ] QA report: `.claude/bmad-output/test-report.md` — verdict PASS (0 P0, 0 P1, 1 P2, 2 P3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)