### PR TITLE
docs: align documentation with dynamic governance and upstream sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [Holacracy Model](#holacracy-model)
 - [Roles Reference](#roles-reference)
 - [Quality Gates](#quality-gates)
+- [Dynamic Governance](#dynamic-governance)
 - [Supported Domains](#supported-domains)
 - [Domain Examples](#domain-examples)
 - [Workflow Orchestrators](#workflow-orchestrators)
@@ -89,6 +90,10 @@ BMAD uses a holacracy-inspired model where each AI role "energizes" a specific p
 
 Per-project behavior can be customized via `bmad-config.yaml` (see `resources/templates/config-example.yaml`).
 
+Additional safeguards enforced by the circle:
+- **Protect Main**: `bmad-impl` and `bmad-greenfield` block work on `main`/`master` — a dedicated feature branch is always required.
+- **TDD Mandatory** (software domain): `bmad-impl` enforces red-green-refactor; `bmad-qa` issues P0 REJECT if `tdd-checklist.md` is missing.
+
 ## Roles Reference
 
 ### Core Workflow Roles
@@ -134,6 +139,19 @@ The **Quality Guardian** (`/bmad-qa`) operates in two modes:
 - **Verify mode** (`/bmad-qa verify`): After implementation — executes tests, validates, reports with P0-P3 verdicts
 
 The **Security Guardian** (`/bmad-security`) can issue a **SECURITY BLOCK** (P0) that prevents the greenfield workflow from advancing to implementation.
+
+## Dynamic Governance
+
+BMAD implements dynamic governance inspired by holacracy's integrative decision-making. Any agent role can detect **tensions** — gaps where no existing role covers a needed capability — and propose new roles on the fly.
+
+**How it works:**
+
+1. **Tension Sensing**: All 8 agent roles monitor for tasks outside their scope. When a recurring or significant gap is detected, the role formulates a tension.
+2. **Role Proposal**: The agent presents a structured proposal to the user (human-in-the-loop). The user can approve, reject, or modify.
+3. **Temporary Roles**: Approved roles exist in the current session context. Orchestrators (`bmad-greenfield`, `bmad-sprint`) can include them in workflow planning.
+4. **Promotion**: After 2+ uses, a temporary role can be promoted to a permanent SKILL.md using the role template (`resources/templates/software/role-template.md`).
+
+The governance protocol is defined in `resources/governance-protocol.md` and loaded on-demand to minimize token usage.
 
 ## Supported Domains
 
@@ -269,13 +287,22 @@ claude-plugin-bmad/
 │   └── bmad.md
 ├── resources/
 │   ├── soul.md                    # Shared circle principles
+│   ├── governance-protocol.md     # Dynamic governance protocol
 │   ├── templates/
 │   │   ├── config-example.yaml    # Per-project config template
 │   │   ├── software/
+│   │   │   ├── role-template.md   # Template for promoting temporary roles
+│   │   │   └── tdd-checklist.md   # TDD cycle tracking template
 │   │   ├── business/
 │   │   └── personal/
 │   └── scripts/
 │       └── detect_domain.sh
+├── .github/
+│   ├── workflows/
+│   │   └── upstream-sync.yml      # Weekly upstream BMAD-METHOD sync monitor
+│   ├── upstream-mapping.json      # Upstream agent → local skill mapping
+│   ├── upstream-snapshot.json     # SHA snapshot of upstream files
+│   └── upstream-version.txt       # Last synced upstream version
 ├── README.md
 └── LICENSE
 ```
@@ -298,6 +325,8 @@ Want to add new skills, workflows, commands, templates, or domains? See the **[C
 
 - BMAD-METHOD: https://github.com/bmad-code-org/BMAD-METHOD
 - Documentation: https://bmadcodes.com/
+- Holacracy: https://www.holacracy.org/
+- Holacracy Constitution: https://github.com/holacracyone/Holacracy-Constitution
 
 ## License
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -27,7 +27,10 @@ claude-plugin-bmad/
 ├── commands/                    # Slash commands (simpler than skills, no frontmatter)
 │   └── bmad.md
 ├── resources/                   # Shared assets referenced by skills
+│   ├── soul.md                  # Shared circle principles
+│   ├── governance-protocol.md   # Dynamic governance protocol (tension sensing, role proposals)
 │   ├── templates/<domain>/      # Output templates per domain
+│   │   └── software/role-template.md  # Template for promoting temporary roles to SKILL.md
 │   └── scripts/                 # Helper scripts
 ├── README.md
 └── LICENSE
@@ -37,7 +40,7 @@ claude-plugin-bmad/
 
 - **Skills** (`skills/*/SKILL.md`) are the primary extension point. Each skill directory is auto-discovered and becomes a `/skill-name` slash command.
 - **Commands** (`commands/*.md`) are simpler slash commands without frontmatter or agent configuration.
-- **Resources** (`resources/`) hold shared assets — `soul.md` (circle principles), templates, scripts — referenced via `${CLAUDE_PLUGIN_ROOT}/resources/...`.
+- **Resources** (`resources/`) hold shared assets — `soul.md` (circle principles), `governance-protocol.md` (dynamic governance), templates, scripts — referenced via `${CLAUDE_PLUGIN_ROOT}/resources/...`.
 - **soul.md** (`resources/soul.md`) defines shared principles loaded by every role in the circle.
 - **Config** (`resources/templates/config-example.yaml`) is a per-project config template users copy to `.claude/bmad-output/bmad-config.yaml`.
 - **Domain detection** is a shared pattern: every skill detects `software`, `business`, `personal`, or `general` from files in the working directory.
@@ -126,6 +129,19 @@ Detect the project domain by analyzing files in the current directory:
 - <Section 2>
 
 **Template**: `${CLAUDE_PLUGIN_ROOT}/resources/templates/personal/<filename>.md`
+
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope and no existing BMAD role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.
 
 ## Process
 
@@ -556,6 +572,7 @@ Every role skill must:
 1. Open with: `You energize the **<Role Title>** role in the BMAD circle.`
 2. Load shared principles: `Read the BMAD circle principles from ${CLAUDE_PLUGIN_ROOT}/resources/soul.md`
 3. Check per-project config: `Check for per-project config at .claude/bmad-output/bmad-config.yaml`
+4. Include a `## Tension Sensing` block referencing `governance-protocol.md` (see Role Skill Template above)
 
 ### Workflow sequence
 


### PR DESCRIPTION
## Summary
- **README.md**: Added Dynamic Governance section, updated Plugin Structure tree (governance-protocol.md, role-template.md, tdd-checklist.md, .github/), added Protect Main & TDD safeguards to Holacracy Model, added holacracy.org and Holacracy Constitution links to References
- **CUSTOMIZATION.md**: Added Tension Sensing block to Role Skill Template (mandatory convention), updated Plugin Architecture with governance-protocol.md and role-template.md, updated Holacracy Pattern conventions
- **CLAUDE.md**: Validated — already consistent post PR #3 and PR #4, no changes needed

## Test plan
- [x] All project files/directories documented in README Plugin Structure
- [x] Cross-consistency between README, CUSTOMIZATION, and CLAUDE.md verified
- [x] No obsolete role names or hardcoded paths
- [x] ToC order matches section order in README
- [x] Holacracy + BMAD links present in References
- [x] QA verdict: PASS (0 P0, 0 P1, 1 P2 fixed, 1 P3 noted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)