### PR TITLE
feat: skills.sh integration with security gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ No build step, no npm, no traditional tests. All content is Markdown.
 - `commands/<name>.md` — simple slash commands (no frontmatter)
 - `resources/soul.md` — shared circle principles (loaded by every role)
 - `resources/governance-protocol.md` — dynamic governance protocol (tension detection, role proposals, promotion)
+- `resources/skill-security-criteria.md` — security criteria for reviewing external skills from skills.sh
 - `resources/templates/<domain>/<name>.md` — output scaffolds (software/business/personal)
 - `resources/templates/software/role-template.md` — template for generating new SKILL.md via promotion
 - `resources/templates/config-example.yaml` — per-project config template
@@ -33,7 +34,7 @@ Circle roles:
 - `/bmad-qa` — Quality Guardian (plan mode + verify mode, P0-P3 gates)
 
 Orchestrators: `/bmad-greenfield`, `/bmad-sprint`
-Utilities: `/bmad-init`, `/bmad-shard`
+Utilities: `/bmad-init`, `/bmad-shard`, `/bmad-skills`
 
 ## Key Conventions
 - All skill template paths use `${CLAUDE_PLUGIN_ROOT}/` — never hardcode absolute paths
@@ -51,6 +52,7 @@ Utilities: `/bmad-init`, `/bmad-shard`
 - Zsh shell: quote `gh api` URLs containing `?` (e.g., `gh api 'repos/.../contents/dir?ref=tag'`)
 - Git rebase continue: use `GIT_EDITOR=true git rebase --continue` (no `--no-edit` flag exists for rebase)
 - **Dynamic Governance**: all 8 agent roles have a `## Tension Sensing` block that references `governance-protocol.md`. Orchestrators have a `## Temporary Roles` section. New roles can be proposed, approved, used temporarily, and promoted to permanent SKILL.md files.
+- **Skills.sh Integration**: `/bmad-skills` discovers and installs external skills from skills.sh with a mandatory security gate. Security criteria in `resources/skill-security-criteria.md`. Verdicts: PASS (low risk), WARN (medium), BLOCK (high — hard stop). `/bmad-init` suggests external skills after domain detection.
 
 ## Testing / Validation
 - `claude --plugin-dir ./claude-plugin-bmad` — local dev testing
@@ -70,12 +72,18 @@ Utilities: `/bmad-init`, `/bmad-shard`
 - Check Tension Sensing in agent roles: `grep -l "Tension Sensing" skills/bmad-{scope,prioritize,arch,impl,qa,ux,security,facilitate}/SKILL.md | wc -l` (should be 8)
 - Check Temporary Roles in orchestrators: `grep -l "Temporary Roles" skills/bmad-{greenfield,sprint}/SKILL.md | wc -l` (should be 2)
 - Check governance-protocol.md sections: `grep -c "Tension Format\|Proposal Flow\|Temporary Role Format\|Promotion Rules" resources/governance-protocol.md` (should be 4)
+- Check bmad-skills skill exists: `[ -f skills/bmad-skills/SKILL.md ] && echo OK`
+- Check skill-security-criteria exists: `[ -f resources/skill-security-criteria.md ] && echo OK`
+- Check bmad-skills uses context same: `grep -q "context: same" skills/bmad-skills/SKILL.md && echo OK`
+- Check security criteria has required sections: `grep -c "PASS\|WARN\|BLOCK\|Patterns to Flag\|Report Format" resources/skill-security-criteria.md` (should be 5+)
+- Check bmad-init references bmad-skills: `grep -q "bmad-skills" skills/bmad-init/SKILL.md && echo OK`
 
 ## Related Repositories
 - Company version (holacracy, quality gates): github.com/alessioroberto82/claude-plugin-bmad
 - PR #1 (`feat/holacracy-evolution`): holacracy migration with soul.md, P0-P3 gates, role renames (merged)
 - PR #2 (`feat/mandatory-tdd-and-branch-protection`): mandatory TDD for software, Protect Main rule, tdd-checklist template
 - PR #3 (`feat/upstream-sync-action`): GitHub Action for upstream BMAD-METHOD release monitoring
+- PR #5 (`docs/update-documentation`): documentation alignment with PR #3 and PR #4, holacracy references
 
 ## Installation (for users)
 - Local: `claude plugin install ./claude-plugin-bmad`

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - [Supported Domains](#supported-domains)
 - [Domain Examples](#domain-examples)
 - [Workflow Orchestrators](#workflow-orchestrators)
+- [Skills Discovery](#skills-discovery)
 - [Context Sharding](#context-sharding)
 - [Output Structure](#output-structure)
 - [Plugin Structure](#plugin-structure)
@@ -122,6 +123,7 @@ Additional safeguards enforced by the circle:
 |---------|---------|-------------|
 | Init | `/bmad-init` | Initialize BMAD in the current project. Run once per project. |
 | Shard | `/bmad-shard` | Context sharding for large documents. Reduces token usage by 90%. |
+| Skills | `/bmad-skills` | Discover, review, and install external skills from skills.sh with security gate. |
 
 ## Quality Gates
 
@@ -234,6 +236,20 @@ Interactive sprint planning ceremony:
 
 6-step process: Backlog Review, Capacity Planning, Story Selection, Task Breakdown, Sprint Goal, Sprint Commitment.
 
+## Skills Discovery
+
+BMAD integrates with [skills.sh](https://skills.sh/) to discover and install community skills with a mandatory security gate:
+
+```bash
+/bmad-skills                    # Suggest skills based on project domain
+/bmad-skills search <query>     # Search skills.sh by keyword
+/bmad-skills install <owner/repo>  # Security review + install
+/bmad-skills review <owner/repo>   # Security review only
+/bmad-skills list               # Show installed external skills
+```
+
+Every skill must pass a security review before installation. The review analyzes tool usage, shell commands, file access, and network patterns. Verdicts: **PASS** (low risk), **WARN** (medium risk — user decides), **BLOCK** (high risk — cannot install). Security criteria are defined in `resources/skill-security-criteria.md`.
+
 ## Context Sharding
 
 For large documents (>3000 tokens), use sharding to reduce token usage by 90%:
@@ -282,12 +298,14 @@ claude-plugin-bmad/
 │   ├── bmad-greenfield/SKILL.md   # Greenfield Orchestrator
 │   ├── bmad-sprint/SKILL.md       # Sprint Orchestrator
 │   ├── bmad-init/SKILL.md         # Init Utility
-│   └── bmad-shard/SKILL.md        # Shard Utility
+│   ├── bmad-shard/SKILL.md        # Shard Utility
+│   └── bmad-skills/SKILL.md       # Skills Discovery & Security Gate
 ├── commands/
 │   └── bmad.md
 ├── resources/
 │   ├── soul.md                    # Shared circle principles
 │   ├── governance-protocol.md     # Dynamic governance protocol
+│   ├── skill-security-criteria.md # Security criteria for external skills
 │   ├── templates/
 │   │   ├── config-example.yaml    # Per-project config template
 │   │   ├── software/

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -29,6 +29,7 @@ claude-plugin-bmad/
 ├── resources/                   # Shared assets referenced by skills
 │   ├── soul.md                  # Shared circle principles
 │   ├── governance-protocol.md   # Dynamic governance protocol (tension sensing, role proposals)
+│   ├── skill-security-criteria.md # Security criteria for reviewing external skills
 │   ├── templates/<domain>/      # Output templates per domain
 │   │   └── software/role-template.md  # Template for promoting temporary roles to SKILL.md
 │   └── scripts/                 # Helper scripts

--- a/resources/skill-security-criteria.md
+++ b/resources/skill-security-criteria.md
@@ -1,0 +1,113 @@
+# Skill Security Criteria
+
+This document defines the security criteria for reviewing external skills from skills.sh before installation. Read this during the security review phase of `/bmad-skills`.
+
+## Risk Classification
+
+### PASS (Low Risk)
+The skill is safe to install. It only reads information and does not modify files or execute commands.
+
+**Allowed tools**:
+- `Read`, `Grep`, `Glob` — read-only file access
+- `WebSearch` — search queries (no data sent)
+
+**Characteristics**:
+- No shell commands
+- No file modifications
+- No external network calls beyond documented APIs
+- No access to sensitive files
+
+### WARN (Medium Risk)
+The skill modifies files or communicates externally. Review carefully before approving.
+
+**Flagged tools**:
+- `Write`, `Edit` — modifies files in the project
+- `WebFetch` — external HTTP communication
+- `Bash` with non-destructive commands (`ls`, `git status`, `npm test`, `npx`, `cat`)
+- `NotebookEdit` — modifies Jupyter notebooks
+
+**Characteristics**:
+- File modifications are scoped to project directory
+- Network calls are to documented, well-known APIs
+- Shell commands are read-only or standard dev tools
+
+### BLOCK (High Risk)
+The skill poses a security threat. Do NOT install.
+
+**Blocked patterns**:
+- `Bash` with destructive commands: `rm -rf`, `rm -f` on paths outside project
+- `Bash` with code execution from network: `curl | sh`, `curl | bash`, `wget | sh`
+- `Bash` with dynamic evaluation: `eval`, `exec`, `source` with untrusted input
+- Access to sensitive files: `.env`, `credentials`, `secrets`, `tokens`, API keys, SSH keys
+- Access to system paths: `~/.ssh/`, `~/.aws/`, `~/.config/`, `/etc/`, `/usr/`
+- Environment variable reading for secrets: `$API_KEY`, `$SECRET`, `$TOKEN`, `$PASSWORD`
+- `dangerouslyDisableSandbox: true` or equivalent bypass flags
+- Obfuscated code: base64-encoded commands, encoded URLs, hex-encoded strings
+- Data exfiltration: `curl -X POST`, `wget --post-data`, outbound `nc`/`netcat`
+
+## Detailed Patterns to Flag
+
+### Shell Command Analysis
+When a skill uses `Bash`, inspect each command for:
+
+| Pattern | Risk | Verdict |
+|---------|------|---------|
+| `rm -rf /` or `rm -rf ~` | Destructive | BLOCK |
+| `rm -rf` on project-scoped paths | Caution | WARN |
+| `curl \| sh` or `curl \| bash` | Remote code execution | BLOCK |
+| `eval "$variable"` | Code injection | BLOCK |
+| `git push --force` | Destructive | WARN |
+| `npm install`, `npx` | Dependency install | WARN |
+| `git status`, `git diff` | Read-only | PASS |
+| `ls`, `cat`, `head` | Read-only | PASS |
+
+### File Access Analysis
+When a skill reads or writes files, check paths for:
+
+| Path Pattern | Risk | Verdict |
+|--------------|------|---------|
+| `.env`, `.env.*` | Secrets exposure | BLOCK |
+| `*credentials*`, `*secret*` | Secrets exposure | BLOCK |
+| `~/.ssh/*`, `~/.aws/*` | System credentials | BLOCK |
+| `~/.config/*` | System config | WARN |
+| Project-scoped paths | Normal | PASS |
+
+### Network Analysis
+When a skill uses `WebFetch` or `Bash` with network commands:
+
+| Pattern | Risk | Verdict |
+|---------|------|---------|
+| `WebFetch` to documented API | External comm | WARN |
+| `curl` GET to known API | External comm | WARN |
+| `curl -X POST` with project data | Data exfiltration | BLOCK |
+| `nc`/`netcat` outbound | Data exfiltration | BLOCK |
+
+## Security Report Format
+
+After analysis, generate a report in this format:
+
+```
+SKILL SECURITY REPORT
+=====================
+Skill: <owner/repo>
+Verdict: PASS | WARN | BLOCK
+
+Risk Level: Low | Medium | High
+Tools Used: [list of tools declared or detected]
+Shell Commands: [list of Bash commands found]
+Files Accessed: [list of file paths referenced]
+Network Calls: [list of URLs or endpoints]
+
+Findings:
+- [Finding 1 with severity]
+- [Finding 2 with severity]
+
+Recommendation: [Install / Review carefully / Do NOT install]
+```
+
+## Verdict Rules
+
+1. If ANY BLOCK pattern is found → verdict is **BLOCK**
+2. If WARN patterns found but no BLOCK → verdict is **WARN**
+3. If only PASS patterns found → verdict is **PASS**
+4. If unable to analyze (repo not accessible) → verdict is **WARN** (caution)

--- a/skills/bmad-init/SKILL.md
+++ b/skills/bmad-init/SKILL.md
@@ -60,5 +60,10 @@ Read the BMAD circle principles from `${CLAUDE_PLUGIN_ROOT}/resources/soul.md` t
    5. /bmad-qa -> validate
    ```
 
-5. **Confirm**:
+5. **Suggest external skills** (optional):
+   "Want to explore community skills from skills.sh for your [domain] project? (y/n)"
+   - If yes: suggest user invokes `/bmad-skills`
+   - If no: proceed without external skills
+
+6. **Confirm**:
    "BMAD circle initialized for domain: <domain>. Start with: /bmad-scope"

--- a/skills/bmad-skills/SKILL.md
+++ b/skills/bmad-skills/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: bmad-skills
+description: Discover, review, and install external skills from skills.sh with mandatory security gate. Domain-aware suggestions. Use anytime to enhance your workflow with community skills.
+context: same
+agent: general-purpose
+argument-hint: "[search <query> | install <owner/repo> | list | review <owner/repo>]"
+---
+
+# Skills Discovery & Secure Installation
+
+You manage the **Skills Discovery** process in the BMAD circle. You help users find, evaluate, and safely install external skills from the skills.sh open ecosystem.
+
+## Shared Principles
+
+Read the BMAD circle principles from `${CLAUDE_PLUGIN_ROOT}/resources/soul.md` and apply them throughout this session. Key principles for this role:
+- **Impact Over Activity**: suggest only skills relevant to the current project
+- **Growth Over Ego**: external skills can complement the circle — embrace the ecosystem
+
+## Domain Detection
+
+Detect the project domain by analyzing files in the current directory:
+- **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
+- **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
+- **general**: default if no indicator found
+
+## Commands
+
+- `/bmad-skills` — suggest skills based on detected domain
+- `/bmad-skills search <query>` — search skills.sh by keyword
+- `/bmad-skills install <owner/repo>` — security review + install
+- `/bmad-skills list` — show installed external skills
+- `/bmad-skills review <owner/repo>` — security review only (no install)
+
+## Prerequisites Check
+
+Before any operation, verify:
+1. **Node.js available**: run `which npx`. If not found, inform user: "npx not found. Install Node.js to use skills.sh integration." and stop.
+2. **Network available**: if operations fail due to network, inform and stop gracefully.
+
+## Process: Domain-Based Discovery
+
+**Trigger**: `/bmad-skills` (no arguments)
+
+1. **Detect domain** using standard domain detection
+2. **Build search queries** based on domain:
+
+   **Software**: analyze `package.json` (if exists) to detect framework:
+   - React/Next.js → search "react", "nextjs"
+   - Vue/Nuxt → search "vue", "nuxt"
+   - Python → search "python"
+   - Go → search "golang"
+   - Default software → search "testing", "linting", "deployment"
+
+   **Business**: search "strategy", "planning", "okr", "business"
+
+   **Personal**: search "productivity", "habits", "journaling"
+
+   **General**: search "best practices" (top results)
+
+3. **Execute search**: run `npx skills find <query>` for each query
+   - If `npx` fails: fallback to `WebFetch https://skills.sh/` and parse results
+4. **Present results** to user:
+   ```
+   Skills suggested for domain: [software]
+
+   1. skill-name (owner/repo) — description [XXK installs]
+   2. skill-name (owner/repo) — description [XXK installs]
+   3. ...
+
+   Select a skill number to review, or 'done' to exit: _
+   ```
+5. **User selects** → proceed to Security Review (below)
+
+## Process: Keyword Search
+
+**Trigger**: `/bmad-skills search <query>`
+
+1. **Execute search**: run `npx skills find <query>`
+   - If `npx` fails: fallback to `WebFetch https://skills.sh/` and parse results
+2. **Present results** (same format as domain-based discovery)
+3. **User selects** → proceed to Security Review
+
+## Process: Install with Security Gate
+
+**Trigger**: `/bmad-skills install <owner/repo>`
+
+1. **Security Review** (mandatory — cannot be skipped):
+
+   a. **Read security criteria**: load `${CLAUDE_PLUGIN_ROOT}/resources/skill-security-criteria.md`
+
+   b. **Fetch skill content** from GitHub:
+      - Run `gh api repos/<owner>/<repo>/contents/` to list files
+      - Fetch SKILL.md content: `gh api repos/<owner>/<repo>/contents/SKILL.md -q .content | base64 -d`
+      - If `gh` fails: use `WebFetch https://github.com/<owner>/<repo>` as fallback
+
+   c. **Analyze content** against security criteria:
+      - Identify tools used (Read, Write, Bash, WebFetch, etc.)
+      - Scan for shell commands and classify each (PASS/WARN/BLOCK patterns)
+      - Check for file access to sensitive paths
+      - Check for network communication patterns
+      - Check for obfuscated code or encoded commands
+
+   d. **Generate security report** using the format from `skill-security-criteria.md`
+
+   e. **Present report to user**:
+
+      If **BLOCK**:
+      ```
+      SKILL SECURITY REPORT
+      =====================
+      Skill: <owner/repo>
+      Verdict: BLOCK
+
+      [report details]
+
+      This skill poses a security risk and cannot be installed.
+      ```
+      **Stop. Do not proceed with installation.**
+
+      If **WARN**:
+      ```
+      SKILL SECURITY REPORT
+      =====================
+      Skill: <owner/repo>
+      Verdict: WARN
+
+      [report details]
+
+      Install this skill? (y/n): _
+      ```
+
+      If **PASS**:
+      ```
+      SKILL SECURITY REPORT
+      =====================
+      Skill: <owner/repo>
+      Verdict: PASS
+
+      [report details]
+
+      Install this skill? (y/n): _
+      ```
+
+2. **If user approves** (PASS or WARN only):
+   - Run `npx skills add <owner/repo>`
+   - Confirm: "Skill <name> installed successfully."
+
+3. **If user rejects**: "Installation cancelled."
+
+## Process: Review Only
+
+**Trigger**: `/bmad-skills review <owner/repo>`
+
+Same as the Security Review steps above, but **never proceeds to installation**. Useful for inspecting a skill before deciding.
+
+## Process: List Installed
+
+**Trigger**: `/bmad-skills list`
+
+1. Run `npx skills list`
+2. Display results to user
+
+## Error Handling
+
+### npx not available
+```
+npx not found. Node.js is required for skills.sh integration.
+Install Node.js: https://nodejs.org/
+```
+
+### skills.sh unreachable
+```
+Could not reach skills.sh. Check your network connection.
+The BMAD workflow continues normally without external skills.
+```
+
+### GitHub repo not accessible
+```
+Could not access <owner/repo> on GitHub.
+The repository may be private or unavailable.
+Verdict: WARN (unable to verify content)
+```
+
+### No results found
+```
+No skills found for "<query>".
+Try a different search term or browse skills.sh directly.
+```
+
+## Tension Sensing
+
+During your work, if you encounter a task that falls outside your defined scope and no existing BMAD role covers it, this is a **tension** — a gap in the circle.
+
+When you detect a tension:
+1. Read `${CLAUDE_PLUGIN_ROOT}/resources/governance-protocol.md`
+2. Formulate the tension using the standard format
+3. Present the proposal to the user for approval
+4. If approved, create the temporary role and continue
+
+Do NOT generate tensions for tasks covered by existing roles.
+Do NOT interrupt flow for minor gaps — only for recurring or significant ones.
+
+## BMAD Principles
+- **Security first**: never install without review — no exceptions
+- **Human-in-the-loop**: user approves every installation
+- **Graceful degradation**: network/tool failures inform, never block the workflow
+- **Impact over activity**: suggest only relevant skills, not everything available


### PR DESCRIPTION
## Summary
- Add `/bmad-skills` skill for discovering, reviewing, and installing external skills from skills.sh
- Mandatory security gate with PASS/WARN/BLOCK verdicts — analyzes tools, shell commands, file access, and network patterns before any installation
- New `resources/skill-security-criteria.md` defining risk classification and analysis patterns
- `/bmad-init` enhanced with optional skills.sh suggestion after domain detection
- Documentation updated across CLAUDE.md, README.md, and CUSTOMIZATION.md

## Test plan
- [ ] Verify `skills/bmad-skills/SKILL.md` exists with correct frontmatter (`context: same`)
- [ ] Verify `resources/skill-security-criteria.md` has PASS/WARN/BLOCK sections and pattern tables
- [ ] Verify `/bmad-init` references `/bmad-skills` in step 5
- [ ] Verify no hardcoded paths in new files
- [ ] Verify all 5 subcommands documented: no-args, search, install, list, review
- [ ] Run `claude --plugin-dir ./claude-plugin-bmad` and test `/bmad-skills` in a sample project

🤖 Generated with [Claude Code](https://claude.com/claude-code)