### PR TITLE
feat: Swift skills integration for BMAD roles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ Utilities: `/bmad-init`, `/bmad-shard`, `/bmad-skills`
 - Git rebase continue: use `GIT_EDITOR=true git rebase --continue` (no `--no-edit` flag exists for rebase)
 - **Dynamic Governance**: all 8 agent roles have a `## Tension Sensing` block that references `governance-protocol.md`. Orchestrators have a `## Temporary Roles` section. New roles can be proposed, approved, used temporarily, and promoted to permanent SKILL.md files.
 - **Skills.sh Integration**: `/bmad-skills` discovers and installs external skills from skills.sh with a mandatory security gate. Security criteria in `resources/skill-security-criteria.md`. Verdicts: PASS (low risk), WARN (medium), BLOCK (high — hard stop). `/bmad-init` suggests external skills after domain detection.
+- **Swift Skills Integration**: For Swift projects (`Package.swift`, `*.xcodeproj`), BMAD roles suggest invoking external Swift expert skills. `bmad-init` suggests installation, `bmad-arch` suggests `/swift-concurrency` and `/swiftui-expert` for architecture, `bmad-impl` suggests contextual skills during implementation, `bmad-qa` suggests `/swift-testing-expert` for test quality. Skills are standalone plugins (AvdLee repos), not bundled. Graceful degradation if not installed.
 
 ## Testing / Validation
 - `claude --plugin-dir ./claude-plugin-bmad` — local dev testing
@@ -77,6 +78,11 @@ Utilities: `/bmad-init`, `/bmad-shard`, `/bmad-skills`
 - Check bmad-skills uses context same: `grep -q "context: same" skills/bmad-skills/SKILL.md && echo OK`
 - Check security criteria has required sections: `grep -c "PASS\|WARN\|BLOCK\|Patterns to Flag\|Report Format" resources/skill-security-criteria.md` (should be 5+)
 - Check bmad-init references bmad-skills: `grep -q "bmad-skills" skills/bmad-init/SKILL.md && echo OK`
+- Check Swift detection in domain blocks: `grep -l "Package.swift" skills/bmad-*/SKILL.md | wc -l` (should be 12)
+- Check bmad-init Swift skill suggestions: `grep -q "SwiftUI Expert" skills/bmad-init/SKILL.md && echo OK`
+- Check bmad-impl Swift recommendations: `grep -q "Swift Skill Recommendations" skills/bmad-impl/SKILL.md && echo OK`
+- Check bmad-arch Swift guidance: `grep -q "Swift Architecture Guidance" skills/bmad-arch/SKILL.md && echo OK`
+- Check bmad-qa Swift Testing: `grep -q "Swift Testing Recommendations" skills/bmad-qa/SKILL.md && echo OK`
 
 ## Related Repositories
 - Company version (holacracy, quality gates): github.com/alessioroberto82/claude-plugin-bmad

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -96,7 +96,7 @@ Check for per-project config at `.claude/bmad-output/bmad-config.yaml`. If found
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
 - **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
 - **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
 - **general**: default if no indicator found
@@ -225,7 +225,7 @@ Check for per-project config at `.claude/bmad-output/bmad-config.yaml`. If found
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
 - **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
 - **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
 - **general**: default if no indicator found
@@ -292,7 +292,7 @@ step1 → step2 → step3 → step4
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
 - **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
 - **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
 - **general**: default if no indicator found
@@ -470,7 +470,7 @@ Every SKILL.md has a Domain Detection section. Add your domain **before** the `g
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
 - **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
 - **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
 - **research**: if `paper.tex`, `bibliography.bib`, `data/` folder, or `experiments/` folder exists
@@ -622,7 +622,7 @@ Every skill includes this identical block:
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
 - **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
 - **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
 - **general**: default if no indicator found

--- a/skills/bmad-arch/SKILL.md
+++ b/skills/bmad-arch/SKILL.md
@@ -18,7 +18,7 @@ Read the BMAD circle principles from `${CLAUDE_PLUGIN_ROOT}/resources/soul.md` a
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
 - **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
 - **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
 - **general**: default if no indicator found
@@ -47,6 +47,19 @@ If no config file exists, use default behavior.
 - Testability (DI strategy, mocking boundaries, test isolation)
 - Performance & Scalability considerations
 - Security considerations
+
+**Swift Architecture Guidance** (if `Package.swift` or `*.xcodeproj` detected):
+
+When designing architecture for a Swift project, suggest:
+- "Invoke `/swift-concurrency` for guidance on actor isolation boundaries, Sendable conformance, and async/await architecture"
+- "Invoke `/swiftui-expert` for SwiftUI state management patterns (@Observable vs ObservableObject) and view composition strategy"
+
+Consider in ADRs:
+- Default actor isolation strategy (module-level @MainActor vs. explicit)
+- Structured vs. unstructured concurrency boundaries
+- State management approach (if SwiftUI)
+
+If a skill is not installed, note: "Skill not installed. Add marketplace: `claude plugin marketplace add AvdLee/{repo-name}`, then install: `claude plugin install {plugin-name}@{marketplace-name}`"
 
 ### Business Strategy
 **Focus**: Process design, workflow, organizational structure

--- a/skills/bmad-facilitate/SKILL.md
+++ b/skills/bmad-facilitate/SKILL.md
@@ -18,7 +18,7 @@ Read the BMAD circle principles from `${CLAUDE_PLUGIN_ROOT}/resources/soul.md` a
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
 - **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
 - **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
 - **general**: default if no indicator found

--- a/skills/bmad-greenfield/SKILL.md
+++ b/skills/bmad-greenfield/SKILL.md
@@ -48,7 +48,7 @@ init -> scope -> prioritize -> ux -> arch -> security -> facilitate -> impl -> q
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
 - **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
 - **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
 - **general**: default if no indicator found

--- a/skills/bmad-impl/SKILL.md
+++ b/skills/bmad-impl/SKILL.md
@@ -18,7 +18,7 @@ Read the BMAD circle principles from `${CLAUDE_PLUGIN_ROOT}/resources/soul.md` a
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
 - **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
 - **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
 - **general**: default if no indicator found
@@ -59,6 +59,16 @@ If no config file exists, use default behavior.
    - **LOG**: Record the cycle in `tdd-checklist.md` (test name, red/green results, refactor notes).
 4. After all behaviors are covered, update the Coverage Summary and Compliance Verdict in `tdd-checklist.md`
 5. Update documentation if necessary
+
+**Swift Skill Recommendations** (if `Package.swift` or `*.xcodeproj` detected):
+
+Before implementing Swift code, suggest invoking relevant expert skills:
+- Working on SwiftUI views → "Invoke `/swiftui-expert` for SwiftUI best practices (state management, view composition, modern APIs)"
+- Working with async/await, actors, or Task → "Invoke `/swift-concurrency` for concurrency guidance (actor isolation, Sendable, Swift 6)"
+- Writing tests → "Invoke `/swift-testing-expert` for Swift Testing patterns (#expect/#require, parameterized tests, XCTest migration)"
+
+These are suggestions, not blocks. The Implementer proceeds with or without them.
+If a skill is not installed, note: "Skill not installed. Add marketplace: `claude plugin marketplace add AvdLee/{repo-name}`, then install: `claude plugin install {plugin-name}@{marketplace-name}`"
 
 ### Business Strategy
 **Activities**:

--- a/skills/bmad-init/SKILL.md
+++ b/skills/bmad-init/SKILL.md
@@ -74,23 +74,11 @@ Read the BMAD circle principles from `${CLAUDE_PLUGIN_ROOT}/resources/soul.md` t
      - Swift Concurrency — async/await, actors, Sendable, Swift 6 migration
      - Swift Testing — modern test framework, #expect/#require, XCTest migration
 
-   Install all? (y/n)
+   Install these skills? (y/n)
    ```
 
-   If yes, provide install commands:
-   ```bash
-   # SwiftUI Expert
-   claude plugin marketplace add AvdLee/SwiftUI-Agent-Skill
-   claude plugin install swiftui-expert@swiftui-expert-skill
-
-   # Swift Concurrency
-   claude plugin marketplace add AvdLee/Swift-Concurrency-Agent-Skill
-   claude plugin install swift-concurrency@swift-concurrency-agent-skill
-
-   # Swift Testing
-   claude plugin marketplace add AvdLee/Swift-Testing-Agent-Skill
-   claude plugin install swift-testing-expert@swift-testing-agent-skill
-   ```
+   If yes: suggest user invokes `/bmad-skills` to discover and install with security review:
+   "Run `/bmad-skills` to review and install Swift expert skills (SwiftUI, Concurrency, Testing from AvdLee)."
 
    If no: proceed without Swift skills.
 

--- a/skills/bmad-init/SKILL.md
+++ b/skills/bmad-init/SKILL.md
@@ -15,7 +15,7 @@ Read the BMAD circle principles from `${CLAUDE_PLUGIN_ROOT}/resources/soul.md` t
 ## Process
 
 1. **Detect domain** by analyzing files in the current directory:
-   - **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+   - **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
    - **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
    - **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
    - **general**: default if no indicator found
@@ -65,5 +65,34 @@ Read the BMAD circle principles from `${CLAUDE_PLUGIN_ROOT}/resources/soul.md` t
    - If yes: suggest user invokes `/bmad-skills`
    - If no: proceed without external skills
 
-6. **Confirm**:
+6. **Suggest Swift skills** (software domain, Swift project only):
+   If `Package.swift` or `*.xcodeproj` exists in the project:
+
+   ```
+   Swift project detected. Recommended expert skills:
+     - SwiftUI Expert — state management, view composition, Liquid Glass (iOS 26+)
+     - Swift Concurrency — async/await, actors, Sendable, Swift 6 migration
+     - Swift Testing — modern test framework, #expect/#require, XCTest migration
+
+   Install all? (y/n)
+   ```
+
+   If yes, provide install commands:
+   ```bash
+   # SwiftUI Expert
+   claude plugin marketplace add AvdLee/SwiftUI-Agent-Skill
+   claude plugin install swiftui-expert@swiftui-expert-skill
+
+   # Swift Concurrency
+   claude plugin marketplace add AvdLee/Swift-Concurrency-Agent-Skill
+   claude plugin install swift-concurrency@swift-concurrency-agent-skill
+
+   # Swift Testing
+   claude plugin marketplace add AvdLee/Swift-Testing-Agent-Skill
+   claude plugin install swift-testing-expert@swift-testing-agent-skill
+   ```
+
+   If no: proceed without Swift skills.
+
+7. **Confirm**:
    "BMAD circle initialized for domain: <domain>. Start with: /bmad-scope"

--- a/skills/bmad-prioritize/SKILL.md
+++ b/skills/bmad-prioritize/SKILL.md
@@ -18,7 +18,7 @@ Read the BMAD circle principles from `${CLAUDE_PLUGIN_ROOT}/resources/soul.md` a
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
 - **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
 - **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
 - **general**: default if no indicator found

--- a/skills/bmad-qa/SKILL.md
+++ b/skills/bmad-qa/SKILL.md
@@ -28,7 +28,7 @@ If no config file exists, use default behavior (TDD enforcement = strict for sof
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
 - **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
 - **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
 - **general**: default if no indicator found
@@ -90,6 +90,13 @@ Detect the project domain by analyzing files in the current directory:
 - Verify edge cases
 - Validate against acceptance criteria
 - Compare with test plan (if exists)
+
+**Swift Testing Recommendations** (if `Package.swift` or `*.xcodeproj` detected):
+
+- Suggest: "Invoke `/swift-testing-expert` for test quality review and modern Swift Testing patterns"
+- If only XCTest imports found (no `import Testing`): suggest migration path to Swift Testing framework
+- Validate: parallel-safe tests, correct use of #expect vs #require, parameterized tests where applicable
+- If a skill is not installed, note: "Skill not installed. Add marketplace: `claude plugin marketplace add AvdLee/Swift-Testing-Agent-Skill`, then install: `claude plugin install swift-testing-expert@swift-testing-agent-skill`"
 
 **Output**: `test-report.md` with:
 - TDD Compliance (pass/fail, cycles logged, coverage of acceptance criteria)

--- a/skills/bmad-scope/SKILL.md
+++ b/skills/bmad-scope/SKILL.md
@@ -18,7 +18,7 @@ Read the BMAD circle principles from `${CLAUDE_PLUGIN_ROOT}/resources/soul.md` a
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
 - **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
 - **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
 - **general**: default if no indicator found

--- a/skills/bmad-security/SKILL.md
+++ b/skills/bmad-security/SKILL.md
@@ -27,7 +27,7 @@ If no config file exists, use default behavior.
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
 - **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
 - **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
 - **general**: default if no indicator found

--- a/skills/bmad-skills/SKILL.md
+++ b/skills/bmad-skills/SKILL.md
@@ -19,7 +19,7 @@ Read the BMAD circle principles from `${CLAUDE_PLUGIN_ROOT}/resources/soul.md` a
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
 - **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
 - **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
 - **general**: default if no indicator found

--- a/skills/bmad-sprint/SKILL.md
+++ b/skills/bmad-sprint/SKILL.md
@@ -18,7 +18,7 @@ Read the BMAD circle principles from `${CLAUDE_PLUGIN_ROOT}/resources/soul.md` a
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
 - **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
 - **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
 - **general**: default if no indicator found

--- a/skills/bmad-ux/SKILL.md
+++ b/skills/bmad-ux/SKILL.md
@@ -18,7 +18,7 @@ Read the BMAD circle principles from `${CLAUDE_PLUGIN_ROOT}/resources/soul.md` a
 ## Domain Detection
 
 Detect the project domain by analyzing files in the current directory:
-- **software**: if `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
+- **software**: if `Package.swift`, `*.xcodeproj`, `package.json`, `pom.xml`, `requirements.txt`, `go.mod`, `Cargo.toml` exists
 - **business**: if `business-plan.md`, `market-analysis.md`, `strategy.md` exists
 - **personal**: if `goals.md`, `journal.md`, or `habits/` folder exists
 - **general**: default if no indicator found


### PR DESCRIPTION
## Summary
- Add Swift project detection (`Package.swift`, `*.xcodeproj`) to all 12 domain detection blocks
- `bmad-init` suggests installing 3 AvdLee Swift expert plugins (SwiftUI, Concurrency, Testing)
- `bmad-arch` suggests `/swift-concurrency` and `/swiftui-expert` for Swift architecture decisions
- `bmad-impl` suggests contextual Swift skills based on code being implemented
- `bmad-qa` suggests `/swift-testing-expert` for test quality review
- Graceful degradation: if skills not installed, shows install commands

## External Skills (standalone plugins, not bundled)
| Plugin | Repo | Purpose |
|---|---|---|
| `swiftui-expert` | AvdLee/SwiftUI-Agent-Skill | SwiftUI best practices, Liquid Glass |
| `swift-concurrency` | AvdLee/Swift-Concurrency-Agent-Skill | async/await, actors, Swift 6 |
| `swift-testing-expert` | AvdLee/Swift-Testing-Agent-Skill | Swift Testing, XCTest migration |

## Test plan
- [x] Domain detection updated in all 12 SKILL.md files
- [x] Swift suggestions in bmad-init verified
- [x] Swift recommendations in bmad-impl verified
- [x] Swift guidance in bmad-arch verified
- [x] Swift Testing in bmad-qa verified
- [x] No regressions: frontmatter, soul.md refs, TDD, Branch Guard all intact
- [x] Security audit of all 3 external skills: PASS (read-only, no shell/network)

🤖 Generated with [Claude Code](https://claude.com/claude-code)